### PR TITLE
Update vpnclient.sswan

### DIFF
--- a/client-conf/vpnclient.sswan
+++ b/client-conf/vpnclient.sswan
@@ -10,5 +10,9 @@
     "rsa-pss": "true"
   },
   "ike-proposal": "aes256-sha256-modp2048",
-  "esp-proposal": "aes128gcm16"
+  "esp-proposal": "aes128gcm16",
+  "split-tunneling": {
+    "block-ipv4": true,
+    "block-ipv6": true
+  }
 }


### PR DESCRIPTION
Fix unwanted behavior when client is using ipv6.  In this case while vpn enabled there is 2 default routes: ipv4 via vpn and ipv6 via default client gateway. 
With these options enabled all client traffic will be routed over vpn tunnel only.